### PR TITLE
`except` fix

### DIFF
--- a/driver/level3/meson.build
+++ b/driver/level3/meson.build
@@ -379,7 +379,7 @@ foreach _kop : driver_kops
         _ext_cargs = []
 
         # Check ext_mappings first
-        if ext_mappings.has_key(ext) and (not ext_mappings.has_key('except') or base not in ext_mappings['except'])
+        if ext_mappings.has_key(ext) and not (ext_mappings[ext].has_key('except') and base in ext_mappings[ext]['except'])
           extmap = ext_mappings[ext]
           if extmap.has_key('def')
             foreach _d : extmap['def']

--- a/meson.build
+++ b/meson.build
@@ -396,10 +396,10 @@ ext_mappings_l3 = [
 
  # symm
  # syrk
- {'ext': '_UN', 'def': [], 'undef': ['LOWER', 'TRANS'], 'for': ['s', 'd', 'c', 'z']},
- {'ext': '_UT', 'def': ['TRANS'], 'undef': ['LOWER'], 'for': ['s', 'd', 'c', 'z']},
- {'ext': '_LN', 'def': ['LOWER'], 'undef': ['TRANS', 'CONJ'], 'for': ['s', 'd', 'c', 'z'], 'except': ['?trmm_kernel']},
- {'ext': '_LT', 'def': ['TRANS', 'LOWER'], 'for': ['s', 'd', 'c', 'z'], 'except': ['?trmm_kernel']},
+ {'ext': '_UN', 'def': [], 'undef': ['LOWER', 'TRANS', 'CONJ'], 'for': ['s', 'd', 'c', 'z']},
+ {'ext': '_UT', 'def': ['TRANS'], 'undef': ['LOWER', 'CONJ'], 'for': ['s', 'd', 'c', 'z']},
+ {'ext': '_LN', 'def': ['LOWER'], 'undef': ['TRANS', 'CONJ'], 'for': ['s', 'd', 'c', 'z']},
+ {'ext': '_LT', 'def': ['TRANS', 'LOWER'], 'undef': ['CONJ'], 'for': ['s', 'd', 'c', 'z']},
  {'ext': '_RU', 'def': ['RSIDE', 'NC'], 'undef': ['LOWER'], 'for': ['c', 'z']},
  {'ext': '_RL', 'def': ['RSIDE', 'NC', 'LOWER'], 'for': ['c', 'z']},
 ]


### PR DESCRIPTION
Hi @HaoZeke,

This is an attempt to fix an issue described in https://github.com/HaoZeke/openblas_buildsys_snips/pull/7.

For some of the `ssyrk` variants, e.g. `UT`, the returned results are incorrect. One issue that I spotted is that in `driver/level3/meson.build` the `except` entry isn't handled properly (fixed in this PR).

As a result all `except` entries in `ext_mappings` dict were ignored. As a result, `syrk` functions used original flags defined in `ext_mappings` instead of those in `ext_mappings_l3`. 

This caused lower-nontranspose to pick these `_LN` flags (again, `except` was ignored):
```python
'_LN': {'def': ['LEFT'], 'undef': ['TRANSA'],
        'except': ['?syrk', '?syrk_thread',
                   '?syr2k', '?herk', '?herk_kernel',
                  '?trsm_kernel']},
```
As a result `ssyrk_LN` was missing `-DLOWER` flag and had `-DLEFT` instead.

But why the error occurred in `ssyrk_UT`? I suspect that it's because the tests were run with NumPy, which is row-major, where the BLAS is Fortran column-major. So upper-transposed became lower-nontransposed (Therefore missing `-DLOWER` flag for `ssyrk_LN` could be the reason of the issue).

Please check if my fix solves it for your setup (I tested it with a `.c` program instead of NumPy tests).

P.S. I also think that `except` entries in `ext_mappings_l3` are ignored so I removed them.