### PR TITLE
BLD: Generate `config.h` header file

### DIFF
--- a/driver/level2/meson.build
+++ b/driver/level2/meson.build
@@ -540,7 +540,7 @@ foreach conf : kernel_confs
     # message(conf)
     _kern_libs += [static_library(
         conf['name'],
-        conf['src'],
+        [conf['src'], config_h],
         include_directories: _inc,
         c_args: conf['c_args'],
     )]

--- a/driver/level3/meson.build
+++ b/driver/level3/meson.build
@@ -454,7 +454,7 @@ foreach conf : kernel_confs
     # message(conf)
     _kern_libs += [static_library(
         conf['name'],
-        conf['src'],
+        [conf['src'], config_h],
         include_directories: _inc,
         c_args: conf['c_args'],
     )]

--- a/driver/others/meson.build
+++ b/driver/others/meson.build
@@ -75,7 +75,7 @@ others_libs = []
 foreach conf : others_confs
   others_libs += [static_library(
     conf['name'],
-    conf['src'],
+    [conf['src'], config_h],
     include_directories: _inc,
     c_args: conf['c_args']
   )]

--- a/getarch_2nd.c
+++ b/getarch_2nd.c
@@ -1,15 +1,16 @@
 #include <stdio.h>
 #ifndef BUILD_KERNEL
 
-#ifndef BUILD_WITH_MESON
-#include "config.h"
-#else
+#ifdef BUILD_WITH_MESON
 #include "_config_for_getarch_2nd.h"
+#else
+#include "config.h"
 #endif
 
 #else
 #include "config_kernel.h"
 #endif
+
 #if (defined(__WIN32__) || defined(__WIN64__) || defined(__CYGWIN32__) || defined(__CYGWIN64__) || defined(_WIN32) || defined(_WIN64)) && defined(__64BIT__)
 typedef long long BLASLONG;
 typedef unsigned long long BLASULONG;

--- a/getarch_2nd.c
+++ b/getarch_2nd.c
@@ -1,6 +1,12 @@
 #include <stdio.h>
 #ifndef BUILD_KERNEL
+
+#ifndef BUILD_WITH_MESON
 #include "config.h"
+#else
+#include "_config_for_getarch_2nd.h"
+#endif
+
 #else
 #include "config_kernel.h"
 #endif

--- a/interface/meson.build
+++ b/interface/meson.build
@@ -621,7 +621,7 @@ foreach conf : _blas_roots
     # Create the static library for each symbol
     lib = static_library(
         sym_name,
-        sources: conf['fname'],
+        sources: [conf['fname'], config_h],
         include_directories: _inc,
         c_args: compiler_args + [
           f'-DASMNAME=@sym_name@',
@@ -643,7 +643,7 @@ foreach conf : _blas_roots
         endif
         cblas_lib = static_library(
             cblas_sym_name,
-            sources: conf['fname'],
+            sources: [conf['fname'], config_h],
             include_directories: _inc,
             c_args: compiler_args + [
               '-DCBLAS',

--- a/join_files.py
+++ b/join_files.py
@@ -1,0 +1,21 @@
+import argparse
+
+
+def merge_files(file1_path: str, file2_path: str) -> str:
+    # Open files in read mode
+    with open(file1_path, 'r') as file1, open(file2_path, 'r') as file2:
+        content1 = file1.read()
+        content2 = file2.read()
+        merged_content = content1 + "\n" + content2
+        return merged_content
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Merge and print content from two text files.")
+    parser.add_argument("file1", help="Path to the first text file.")
+    parser.add_argument("file2", help="Path to the second text file.")
+
+    args = parser.parse_args()
+
+    output = merge_files(args.file1, args.file2)
+    print(output)

--- a/kernel/meson.build
+++ b/kernel/meson.build
@@ -1274,7 +1274,7 @@ _is_asm = false
 foreach conf: kernel_confs
   _kern_libs += static_library(
       conf['name'],
-      conf['src'],
+      [conf['src'], config_h],
       include_directories:  _inc,
       c_args: conf['c_args'],
       # See gh discussion 13374 for why, basically .S are coded as fortran..

--- a/lapack-netlib/meson.build
+++ b/lapack-netlib/meson.build
@@ -1,8 +1,8 @@
 add_languages('fortran', native: false)
 ff = meson.get_compiler('fortran')
-if ff.has_argument('-Wno-conversion')
-  add_project_arguments('-Wno-conversion', language: 'fortran')
-endif
+# if ff.has_argument('-Wno-conversion')
+#   add_project_arguments('-Wno-conversion', language: 'fortran')
+# endif
 
 lapack_major_version = 3 # soversion
 lapack_minor_version = 12

--- a/lapack-netlib/meson.build
+++ b/lapack-netlib/meson.build
@@ -1,5 +1,6 @@
 add_languages('fortran', native: false)
 ff = meson.get_compiler('fortran')
+# TODO(mtsokol): make it a local setting
 # if ff.has_argument('-Wno-conversion')
 #   add_project_arguments('-Wno-conversion', language: 'fortran')
 # endif

--- a/meson.build
+++ b/meson.build
@@ -22,6 +22,7 @@ openblas_version = f'@openblas_major_version@.@openblas_minor_version@.@openblas
 # Skip the check for valid CC
 cc = meson.get_compiler('c')
 fc = meson.get_compiler('fortran')
+cc_id = cc.get_id()
 fc_id = fc.get_id()
 
 # Common args
@@ -415,8 +416,10 @@ symb_defs = {
 
 # config.h file generation
 
-run_command('c_check', 'Makefile.conf', './build/_config_1.h', 'gcc')
-run_command('f_check', 'Makefile.conf', './build/_config_1.h', 'gfortran')
+_config_1_path = meson.current_build_dir() / '_config_1.h'
+_join_files_py = '../join_files.py'
+run_command('./c_check', 'Makefile.conf', _config_1_path, cc_id, check: true)
+run_command('./f_check', 'Makefile.conf', _config_1_path, fc_id, check: true)
 
 getarch = executable('getarch', ['getarch.c', 'cpuid.S'])
 
@@ -429,7 +432,12 @@ _config_2h = custom_target('_config_2h',
 
 _config_for_getarch_2nd_h = custom_target('_config_for_getarch_2nd_h',
                                           output: '_config_for_getarch_2nd.h',
-                                          command: [find_program('cat'), './_config_1.h', _config_2h],
+                                          command: [
+                                            find_program('python'),
+                                            _join_files_py,
+                                            _config_1_path,
+                                            _config_2h,
+                                          ],
                                           depends: [_config_2h],
                                           capture: true,
                                          )
@@ -448,7 +456,12 @@ _config_3h = custom_target('_config_3h',
 
 config_h = custom_target('config_h',
                          output: 'config.h',
-                         command: [find_program('cat'), _config_for_getarch_2nd_h, _config_3h],
+                         command: [
+                           find_program('python'),
+                           _join_files_py,
+                           _config_for_getarch_2nd_h,
+                           _config_3h,
+                         ],
                          depends: [_config_3h],
                          capture: true,
                         )

--- a/meson.build
+++ b/meson.build
@@ -11,7 +11,7 @@
 #
 # NOTE: This is still a work in progress, the Makefiles are canonical
 project('OpenBLAS', ['c', 'fortran'],
-        default_options: ['c_std=c99', 'pkg.relocatable=true'],
+        default_options: ['c_std=c99', 'pkgconfig.relocatable=true'],
         version: '0.3.26.dev')
 
 openblas_major_version = 0 # soversion
@@ -67,46 +67,6 @@ else
     no_affinity = false
 endif
 
-# Makefile.prebuild stuff
-# TODO(rg): Generate within meson
-# getarch = executable('getarch',
-#           ['getarch.c', 'cpuid.S'])
-# getarch_two = executable('getarch_2nd',
-#                          ['getarch_2nd.c'])
-cchk=custom_target(
-  'c_checks',
-  output: ['Makefile_c.conf', 'config_c.h'],
-  input: ['ctest.c'],
-  command: [find_program('c_check'), 'Makefile_c.conf', 'config_c.h', 'gcc'],
-)
-fchk=custom_target(
-  'f_checks',
-  output: ['Makefile_f.conf', 'config_f.h'],
-  command: [find_program('f_check'), 'Makefile_f.conf', 'config_f.h', 'gfortran'],
-)
-fs = import('fs')
-basic_config = custom_target(
-  'basic_config',
-  output: ['config.h'],
-  input: [cchk, fchk],
-  command: [find_program('python'),
-            'write_file.py', 'config.h',
-            'config_c.h', 'config_f.h']
-)
-
-getarch = executable('getarch',
-          ['getarch.c', 'cpuid.S', basic_config,])
-getarch_two = executable('getarch_2nd',
-                         ['getarch_2nd.c', basic_config,])
-# gch = run_command('c_check', 'Makefile.conf', 'config.h', 'gcc')
-# run_command('f_check', 'Makefile.conf', 'config.h', 'gcc')
-# outp = gch.stdout().strip()
-# config_h = custom_target('gen_config_h',
-#                           # input: ['getarch.c'],
-#                           output: ['config.h'],
-#                           command: [getarch, '3']
-#                           )
-
 _check_prefix = []
 conf_data = configuration_data()
 is_win = host_machine.system() == 'windows' or host_machine.system() == 'cygwin'
@@ -142,18 +102,6 @@ endforeach
 
 configure_file(output : 'getarch_conf.h',
                configuration : conf_data)
-
-# run_target('generate_config_h',
-#            command: [meson.current_build_dir() + '/getarch', '1'],
-#            depends: getarch)
-
-# gch = run_command(meson.current_build_dir() + '/getarch', '1')
-# outp = gch.stdout().strip()
-
-# conf_data = configuration_data()
-# configure_file(input : meson.current_build_dir() + '/config.h',
-#   output : 'config.h',
-#   configuration : conf_data)
 
 # Makefile.system
 cpu_fam = target_machine.cpu_family()
@@ -464,6 +412,46 @@ symb_defs = {
     'cblas_?dotu_sub':  {'def': ['CBLAS', 'FORCE_USE_STACK'], 'undef': ['CONJ']},
     'cblas_?dotc_sub':  {'def': ['CBLAS', 'FORCE_USE_STACK', 'CONJ']},
 }
+
+# config.h file generation
+
+run_command('c_check', 'Makefile.conf', './build/_config_1.h', 'gcc')
+run_command('f_check', 'Makefile.conf', './build/_config_1.h', 'gfortran')
+
+getarch = executable('getarch', ['getarch.c', 'cpuid.S'])
+
+_config_2h = custom_target('_config_2h',
+                           output: '_config_2.h',
+                           command: [getarch, '1'],
+                           depends: [getarch],
+                           capture: true,
+                          )
+
+_config_for_getarch_2nd_h = custom_target('_config_for_getarch_2nd_h',
+                                          output: '_config_for_getarch_2nd.h',
+                                          command: [find_program('cat'), './_config_1.h', _config_2h],
+                                          depends: [_config_2h],
+                                          capture: true,
+                                         )
+
+getarch_2nd = executable('getarch_2nd',
+                         ['getarch_2nd.c', _config_for_getarch_2nd_h],
+                         c_args: ['-DGEMM_MULTITHREAD_THRESHOLD=4', '-DBUILD_WITH_MESON']
+                        )
+
+_config_3h = custom_target('_config_3h',
+                           output: '_config_3.h',
+                           command: [getarch_2nd, '1'],
+                           depends: [getarch_2nd],
+                           capture: true,
+                          )
+
+config_h = custom_target('config_h',
+                         output: 'config.h',
+                         command: [find_program('cat'), _config_for_getarch_2nd_h, _config_3h],
+                         depends: [_config_3h],
+                         capture: true,
+                        )
 
 # Ignoring other hostarch checks and conflicts for arch in BSD for now
 _inc = [include_directories('.')]


### PR DESCRIPTION
Hi @HaoZeke,

Here's my attempt to generate `config.h` file for OpenBLAS project.

With this change I can successfully build it on `qgpu` Linux machine with commands:
```bash
meson setup build --reconfigure --buildtype release
meson compile -C build
```

## Design

The `config.h` header generation is divided into several steps:
1. First we need to run `c_check` and `f_check` scripts. This is done in the `setup` stage by using `run_command(...)`. Thanks to this we have `_config_1.h` with the first batch of contents. TODO: `./build/` path is hardcoded. It should use meson-provided path.
2. The rest of steps happen in `meson compile` stage. Then we compile `getarch`.
3. Next we define a custom target `_config_2.h` that is the output of `./getarch 1`
4. Then we merge `_config_1.h` and `_config_2.h` into `_config_for_getarch_2nd.h` into one custom target.
5. Compiling `getarch_2nd` with `_config_for_getarch_2nd_h` dependency.
6. The last piece of header input that we need is `_config_3.h` which is a custom target from calling `./getarch_2nd 1`.
7. The last step is merging `_config_for_getarch_2nd.h` and `_config_3.h` into a final `config.h`.

Then I add `config_h` as an input in all `static_library(...)` which require `config.h` header.
I followed the pattern described in https://mesonbuild.com/Generating-sources.html#generating-headers to implement it. Ideally we could remove the intermediate `_config...h` but it's a detail.

## Questions

- WDYT about this approach? The generated `config.h` is exactly as `make` one on my Linux machine.
- In `getarch_2nd.c` I had to add an `#ifndef` to include my merged pre-header as meson doesn't allow targets with the same name. It's behind a `BUILD_WITH_MESON` that I set in `meson.build`. Does it make sense?
- I had to comment out three lines in `lapack-netlib/meson.build` as `add_project_arguments` can't happen after the first `custom_target` (I think) but it only sets a warning flag.


