### PR TITLE
ENH: Setup configuration object for dependent arch

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -503,6 +503,37 @@ config_h = custom_target('config_h',
                          capture: true,
                         )
 
+# Parse config back in
+_config_h_path = meson.current_build_dir() / 'config.h'
+_read_config_py = '../read_config.py'
+
+conf_kconf = custom_target('conf_kconf',
+                          output: 'config.kconf',
+                          command: [
+                            py3,
+                            _read_config_py,
+                            config_h,
+                          ],
+                          depends: [config_h],
+                          capture: true,
+                          )
+
+keyval = import('keyval')
+conf_kv = keyval.load(meson.current_build_dir() / 'config.kconf')
+# NOTE(rg): conf_kv doesn't do any parsing, setup manually
+conf_hdat = configuration_data()
+foreach key,val : conf_kv
+  if 'CHAR' in key
+       conf_hdat.set_quoted(key, val)
+    else
+      conf_hdat.set(key, val)
+  endif
+endforeach
+
+# To check if things are OK
+# configure_file(output : 'dummy_conf.h',
+#                configuration : conf_hdat)
+
 # Ignoring other hostarch checks and conflicts for arch in BSD for now
 _inc = [include_directories('.')]
 subdir('lapack-netlib')
@@ -554,7 +585,8 @@ pcl = custom_target('prepare_config_last',
              exprecision ? '--exprecision' : [],
             ],
   build_by_default : true,
-  depends: config_h,
+  # kconf isn't needed but won't be generated otherwise
+  depends: [ config_h, conf_kconf ],
 )
 
 # Generate the headers

--- a/read_config.py
+++ b/read_config.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+
+import argparse
+
+def read_config_file(file_path: str) -> dict:
+    config_data = {}
+    with open(file_path, "r") as file:
+        lines = file.readlines()
+        for line in lines:
+            line = line.strip()
+            if line.startswith("#define"):
+                parts = line.split()
+                key = parts[1]
+                if len(parts) == 3:
+                    value = parts[2]
+                    if value.isdigit():
+                        value = int(value)
+                    elif value.startswith('"') and value.endswith('"'):
+                        value = value.strip('"')
+                    config_data[key] = value
+                elif len(parts) == 2:
+                    config_data[key] = 1
+    return config_data
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Read a config.h file.")
+    parser.add_argument("file1", help="Path to the config.h file.")
+
+    args = parser.parse_args()
+
+    config_data = read_config_file(args.file1)
+    fdat = []
+    for key, value in config_data.items():
+        fdat.append(f'{key}={value}')
+    print('\n'.join(fdat))


### PR DESCRIPTION
Sets up `conf_hdat` for conditionally swapping kernel files for symbols.