### PR TITLE
BLD: silence harmless and verbose build warnings

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -154,6 +154,24 @@ else
   add_project_arguments(f'-DF_INTERFACE_@upper_fcid@', language: 'c')
 endif
 
+# Warnings from LAPACK that we're not interested in seeing:
+add_project_arguments(
+  fc.get_supported_arguments(
+    '-Wno-conversion',
+    '-Wno-maybe-uninitialized',
+    '-Wno-unused-dummy-argument',
+    '-Wno-unused-variable',
+  ),
+  language: 'fortran'
+)
+add_project_arguments(
+  cc.get_supported_arguments(
+    '-Wno-unused-function',
+    '-Wno-unused-variable',
+  ),
+  language: 'c'
+)
+
 py3 = find_program('python')
 
 simd_extensions = [


### PR DESCRIPTION
These are for the vast majority coming from the vendored Netlib code. With all of these warnings silenced we'll be able to look at the build log for relevant warnings and errors.

Submitting a PR to get some CI signal; more to follow in another PR.